### PR TITLE
Add simple web server and Procfile web entry

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: python server.py
 worker: python main.py

--- a/server.py
+++ b/server.py
@@ -1,0 +1,14 @@
+import os
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+
+def run():
+    port = int(os.environ.get("PORT", 5000))
+    handler = SimpleHTTPRequestHandler
+    with HTTPServer(("", port), handler) as httpd:
+        print(f"Serving on port {port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- Add a `server.py` script that starts a basic HTTP server on the `PORT` env var
- Update `Procfile` to include `web: python server.py`

## Testing
- `python -m py_compile ai.py game.py main.py utils.py server.py`
- `PORT=8123 python server.py &` then `curl -I localhost:8123`
- `heroku ps:scale web=1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896167f8b488321ab3e8aef574f0201